### PR TITLE
Fix ERR_PRP_REF error for private properties used in orderBy clauses.

### DIFF
--- a/klass-model-converters/klass-compiler-tests/src/test/inputresources/cool/klass/model/converter/compiler/annotation/property/UnreferencedPrivatePropertiesTest.klass
+++ b/klass-model-converters/klass-compiler-tests/src/test/inputresources/cool/klass/model/converter/compiler/annotation/property/UnreferencedPrivatePropertiesTest.klass
@@ -1,0 +1,45 @@
+package cool.klass.model.converter.compiler.annotation.property
+
+class RelatedClass
+{
+    id: String key;
+    normalProperty: String;
+}
+
+class ExampleClass
+{
+    id: String key;
+    relatedClassId: String private;
+    name: String;
+    privateUsedInAssociationCriteria: String private;
+    privateUsedInServiceCriteria: String private;
+    privateUsedInAssociationOrderBy: Integer private;
+    privateUsedInServiceOrderBy: Integer private;
+    privateUnreferenced: Integer private;
+}
+
+association ExampleToRelated
+{
+    example: ExampleClass[0..*] orderBy: this.privateUsedInAssociationOrderBy ascending;
+    related: RelatedClass[1..1];
+
+    relationship this.relatedClassId == RelatedClass.id && this.privateUsedInAssociationCriteria == "test"
+}
+
+projection ExampleProjection on ExampleClass
+{
+    id: "ID",
+    name: "Name",
+}
+
+service ExampleClassResource on ExampleClass
+{
+    /examples
+        GET
+        {
+            multiplicity: many;
+            criteria: this.privateUsedInServiceCriteria == "test";
+            projection: ExampleProjection;
+            orderBy: this.privateUsedInServiceOrderBy ascending;
+        }
+}

--- a/klass-model-converters/klass-compiler-tests/src/test/java/cool/klass/model/converter/compiler/annotation/property/UnreferencedPrivatePropertiesTest.java
+++ b/klass-model-converters/klass-compiler-tests/src/test/java/cool/klass/model/converter/compiler/annotation/property/UnreferencedPrivatePropertiesTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025 Craig Motlin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cool.klass.model.converter.compiler.annotation.property;
+
+import cool.klass.model.converter.compiler.annotation.AbstractKlassCompilerErrorTestCase;
+
+public class UnreferencedPrivatePropertiesTest
+        extends AbstractKlassCompilerErrorTestCase
+{
+    @Override
+    public void smokeTest()
+    {
+        this.assertCompilationSucceeds(true);
+    }
+}

--- a/klass-model-converters/klass-compiler-tests/src/test/resources/cool/klass/model/converter/compiler/annotation/property/UnreferencedPrivatePropertiesTest-18-4-ERR_PRP_REF.log
+++ b/klass-model-converters/klass-compiler-tests/src/test/resources/cool/klass/model/converter/compiler/annotation/property/UnreferencedPrivatePropertiesTest-18-4-ERR_PRP_REF.log
@@ -1,0 +1,17 @@
+════════════════════════════════════════ [35mERR_PRP_REF[m ════════════════════════════════════════
+[33mWarning: Private property 'ExampleClass.privateUnreferenced' is not referenced in any criteria.[m
+
+At (UnreferencedPrivatePropertiesTest.klass:18)
+
+[39m 1║ [35mpackage [39mcool[36m.[39mklass[36m.[39mmodel[36m.[39mconverter[36m.[39mcompiler[36m.[39mannotation[36m.[39mproperty
+[39m 9║ [35mclass [39mExampleClass
+[39m10║ [36m{
+[39m18║     [39mprivateUnreferenced[36m: [35mInteger [32mprivate[36m;
+[39m  ║ [33m    ^^^^^^^^^^^^^^^^^^^
+[39m19║ [36m}
+[m
+[36mLocation:  [mUnreferencedPrivatePropertiesTest.klass:18[m
+[36mFile:      [mUnreferencedPrivatePropertiesTest.klass[m
+[36mLine:      [m18[m
+[36mCharacter: [m5
+═════════════════════════════════════════════════════════════════════════════════════════════

--- a/klass-model-converters/klass-compiler/src/main/java/cool/klass/model/converter/compiler/state/UnreferencedPrivatePropertiesOrderByVisitor.java
+++ b/klass-model-converters/klass-compiler/src/main/java/cool/klass/model/converter/compiler/state/UnreferencedPrivatePropertiesOrderByVisitor.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024 Craig Motlin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cool.klass.model.converter.compiler.state;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import javax.annotation.Nonnull;
+
+import cool.klass.model.converter.compiler.state.order.AntlrOrderBy;
+import cool.klass.model.converter.compiler.state.order.AntlrOrderByMemberReferencePath;
+import cool.klass.model.converter.compiler.state.order.AntlrOrderByVisitor;
+import cool.klass.model.converter.compiler.state.property.AntlrAssociationEnd;
+import cool.klass.model.converter.compiler.state.property.AntlrDataTypeProperty;
+import cool.klass.model.converter.compiler.state.value.AntlrThisMemberReferencePath;
+
+public class UnreferencedPrivatePropertiesOrderByVisitor
+        implements AntlrOrderByVisitor
+{
+    private final Set<AntlrAssociationEnd> associationEndsReferencedByOrderBy = new LinkedHashSet<>();
+    private final Set<AntlrDataTypeProperty<?>> dataTypePropertiesReferencedByOrderBy = new LinkedHashSet<>();
+    private final UnreferencedPrivatePropertiesExpressionValueVisitor expressionValueVisitor = new UnreferencedPrivatePropertiesExpressionValueVisitor();
+
+    public Set<AntlrAssociationEnd> getAssociationEndsReferencedByOrderBy()
+    {
+        return this.associationEndsReferencedByOrderBy;
+    }
+
+    public Set<AntlrDataTypeProperty<?>> getDataTypePropertiesReferencedByOrderBy()
+    {
+        return this.dataTypePropertiesReferencedByOrderBy;
+    }
+
+    @Override
+    public void visit(@Nonnull AntlrOrderBy orderBy)
+    {
+        for (AntlrOrderByMemberReferencePath memberReferencePath : orderBy.getOrderByMemberReferencePaths())
+        {
+            this.visit(memberReferencePath);
+        }
+    }
+
+    private void visit(@Nonnull AntlrOrderByMemberReferencePath memberReferencePath)
+    {
+        AntlrThisMemberReferencePath thisMemberReferencePath = memberReferencePath.getThisMemberReferencePath();
+        thisMemberReferencePath.visit(this.expressionValueVisitor);
+
+        this.associationEndsReferencedByOrderBy.addAll(this.expressionValueVisitor.getAssociationEndsReferencedByCriteria());
+        this.dataTypePropertiesReferencedByOrderBy.addAll(this.expressionValueVisitor.getDataTypePropertiesReferencedByCriteria());
+    }
+}

--- a/klass-model-converters/klass-compiler/src/main/java/cool/klass/model/converter/compiler/state/order/AntlrOrderBy.java
+++ b/klass-model-converters/klass-compiler/src/main/java/cool/klass/model/converter/compiler/state/order/AntlrOrderBy.java
@@ -81,6 +81,12 @@ public class AntlrOrderBy
         return this.orderByOwner instanceof AntlrService;
     }
 
+    @Nonnull
+    public ImmutableList<AntlrOrderByMemberReferencePath> getOrderByMemberReferencePaths()
+    {
+        return this.orderByMemberReferencePaths.toImmutable();
+    }
+
     @Override
     public Pair<Token, Token> getContextBefore()
     {
@@ -142,5 +148,10 @@ public class AntlrOrderBy
     public OrderByBuilder getElementBuilder()
     {
         return Objects.requireNonNull(this.elementBuilder);
+    }
+
+    public void visit(@Nonnull AntlrOrderByVisitor visitor)
+    {
+        visitor.visit(this);
     }
 }

--- a/klass-model-converters/klass-compiler/src/main/java/cool/klass/model/converter/compiler/state/order/AntlrOrderByMemberReferencePath.java
+++ b/klass-model-converters/klass-compiler/src/main/java/cool/klass/model/converter/compiler/state/order/AntlrOrderByMemberReferencePath.java
@@ -81,6 +81,12 @@ public class AntlrOrderByMemberReferencePath
         return this.orderByDirection;
     }
 
+    @Nonnull
+    public AntlrThisMemberReferencePath getThisMemberReferencePath()
+    {
+        return this.thisMemberReferencePath;
+    }
+
     public void reportErrors(@Nonnull CompilerAnnotationHolder compilerAnnotationHolder)
     {
         // TODO: ❗️ Redo context stack for error reporting

--- a/klass-model-converters/klass-compiler/src/main/java/cool/klass/model/converter/compiler/state/order/AntlrOrderByVisitor.java
+++ b/klass-model-converters/klass-compiler/src/main/java/cool/klass/model/converter/compiler/state/order/AntlrOrderByVisitor.java
@@ -16,27 +16,9 @@
 
 package cool.klass.model.converter.compiler.state.order;
 
-import java.util.Optional;
-
 import javax.annotation.Nonnull;
 
-import cool.klass.model.converter.compiler.state.IAntlrElement;
-import org.eclipse.collections.api.list.ImmutableList;
-import org.eclipse.collections.impl.factory.Lists;
-
-public interface AntlrOrderByOwner
-        extends IAntlrElement
+public interface AntlrOrderByVisitor
 {
-    void enterOrderByDeclaration(@Nonnull AntlrOrderBy orderBy);
-
-    @Nonnull
-    Optional<AntlrOrderBy> getOrderBy();
-
-    @Nonnull
-    default ImmutableList<AntlrOrderBy> getOrderBys()
-    {
-        return this.getOrderBy()
-                .map(Lists.immutable::with)
-                .orElseGet(Lists.immutable::empty);
-    }
+    void visit(@Nonnull AntlrOrderBy orderBy);
 }

--- a/klass-models/klass-model-meta/src/main/java/cool/klass/model/meta/domain/value/literal/LiteralListValueImpl.java
+++ b/klass-models/klass-model-meta/src/main/java/cool/klass/model/meta/domain/value/literal/LiteralListValueImpl.java
@@ -69,7 +69,7 @@ public final class LiteralListValueImpl
     {
         if (this.literalValues != null)
         {
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("Literal values already set");
         }
         this.literalValues = Objects.requireNonNull(literalValues);
     }


### PR DESCRIPTION
This fixes the warning 'Private property X is not referenced in any criteria' for private properties that are used in orderBy clauses. The compiler now considers properties referenced in orderBy clauses as properly referenced.