### PR TITLE
Extract inheritance-based ERR_PRJ_CRF test to separate test class

### DIFF
--- a/klass-model-converters/klass-compiler-tests/src/test/inputresources/cool/klass/model/converter/compiler/annotation/projection/ProjectionRedundantClassifierQualifierInheritedTest.klass
+++ b/klass-model-converters/klass-compiler-tests/src/test/inputresources/cool/klass/model/converter/compiler/annotation/projection/ProjectionRedundantClassifierQualifierInheritedTest.klass
@@ -1,0 +1,36 @@
+package dummy
+
+class Base
+    abstract
+{
+    id: Long key;
+    baseParentId: Long? private;
+}
+
+class Sub
+    extends Base
+{
+    id: Long key;
+}
+
+class Target
+{
+    id: Long key;
+}
+
+association BaseHasParent
+{
+    baseChild: Base[0..*];
+    parent: Target[0..1];
+
+    relationship this.baseParentId == Target.id
+}
+
+projection SubProjection on Sub
+{
+    id: "ID",
+    Sub.parent:
+    {
+        id: "Target ID",
+    },
+}

--- a/klass-model-converters/klass-compiler-tests/src/test/java/cool/klass/model/converter/compiler/annotation/projection/ProjectionRedundantClassifierQualifierInheritedTest.java
+++ b/klass-model-converters/klass-compiler-tests/src/test/java/cool/klass/model/converter/compiler/annotation/projection/ProjectionRedundantClassifierQualifierInheritedTest.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2026 Craig Motlin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cool.klass.model.converter.compiler.annotation.projection;
+
+import cool.klass.model.converter.compiler.annotation.AbstractKlassCompilerErrorTestCase;
+
+public class ProjectionRedundantClassifierQualifierInheritedTest extends AbstractKlassCompilerErrorTestCase {}

--- a/klass-model-converters/klass-compiler-tests/src/test/resources/cool/klass/model/converter/compiler/annotation/projection/ProjectionRedundantClassifierQualifierInheritedTest-32-4-ERR_PRJ_CRF.log
+++ b/klass-model-converters/klass-compiler-tests/src/test/resources/cool/klass/model/converter/compiler/annotation/projection/ProjectionRedundantClassifierQualifierInheritedTest-32-4-ERR_PRJ_CRF.log
@@ -1,0 +1,19 @@
+════════════════════════════════════════ [35mERR_PRJ_CRF[m ════════════════════════════════════════
+[31mError: Redundant classifier qualifier 'Sub' on projection member 'parent'. The property can be resolved without the qualifier.[m
+
+At (ProjectionRedundantClassifierQualifierInheritedTest.klass:32:5)
+
+[39m 1║ [35mpackage [39mdummy
+[39m29║ [35mprojection [39mSubProjection [35mon [39mSub
+[39m30║ [36m{
+[39m32║     [39mSub[36m.[39mparent[36m:
+[39m  ║ [31m    ^^^
+[39m33║     [36m{
+[39m35║     [36m}[36m,
+[39m36║ [36m}
+[m
+[36mLocation:  [mProjectionRedundantClassifierQualifierInheritedTest.klass:32:5[m
+[36mFile:      [mProjectionRedundantClassifierQualifierInheritedTest.klass[m
+[36mLine:      [m32[m
+[36mCharacter: [m5
+═════════════════════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

- Extracts the inheritance-based ERR_PRJ_CRF test into a new separate test class `ProjectionRedundantClassifierQualifierInheritedTest`, instead of modifying the existing `ProjectionDuplicateNameOverlapTest`
- Tests that `Sub.parent` triggers ERR_PRJ_CRF when `parent` is inherited from `Base` superclass — the qualifier is redundant because the property resolves through inheritance

## Test plan

- All 74 compiler tests pass
- Pre-commit checks pass