### PR TITLE
Upgrade just to 1.52.0

### DIFF
--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -1,6 +1,6 @@
 [tools]
 java = "temurin-21.0.9+10.0.LTS"
-just = "1.46.0"
+just = "1.52.0"
 maven = "3.9.12"
 mvnd = "1.0.3"
 node = "24.13.0"


### PR DESCRIPTION
Bumps the pinned `just` version to 1.52.0 in `.mise/config.toml` to match the project-template baseline.